### PR TITLE
apply reduction ratio to waist_roll_motors [hip]

### DIFF
--- a/protos/GankenKun.proto
+++ b/protos/GankenKun.proto
@@ -683,10 +683,10 @@ PROTO GankenKun [
               device [
                 RotationalMotor {
                   name "left_waist_roll_joint [hip]"
-                  maxVelocity %{= b3msc1170_maxVelo }%
+                  maxVelocity %{= b3msc1170_maxVelo / 2.0 }%
                   minPosition -5.58505360638185
                   maxPosition  5.58505360638185
-                  maxTorque %{= b3msc1170_torque }%
+                  maxTorque %{= b3msc1170_torque * 2.0 }%
                 }
                 PositionSensor {
                   name "left_waist_roll_joint [hip]_sensor"
@@ -1324,10 +1324,10 @@ PROTO GankenKun [
               device [
                 RotationalMotor {
                   name "right_waist_roll_joint [hip]"
-                  maxVelocity %{= b3msc1170_maxVelo }%
+                  maxVelocity %{= b3msc1170_maxVelo / 2.0 }%
                   minPosition -5.58505360638185
                   maxPosition  5.58505360638185
-                  maxTorque %{= b3msc1170_torque }%
+                  maxTorque %{= b3msc1170_torque * 2.0 }%
                 }
                 PositionSensor {
                   name "right_waist_roll_joint [hip]_sensor"


### PR DESCRIPTION
実機では揺動スライダクランク機構によって2倍に減速されている腰ロールモーターに対して、webotsモデルのそれが持つ最大トルクと最大速度に減速比を適用した。具体的には最大速度を1/2倍、最大トルクを2倍した。
vhscで利用していた制御プログラム(hr46_b3m)では、今までも減速比を考慮していない目標角度を送信していたようであるので少なくとも歩行制御を更新する必要は無さそう。